### PR TITLE
v1.1.0 release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,27 @@ queue
 }
 ```
 
+## Graceful Shutdown
+
+Once initialized, a queue can be gracefully shutdown by calling its `shutdown()` function. This prevents workers from claiming new tasks, removes all Firebase listeners, and waits until all the current tasks have been completed before resolving the RSVP.Promise returned by the function.
+
+By intercepting for the `SIGINT` termination signal like this, you can ensure the queue shuts down gracefully so you don't have to rely on the jobs timing out and being picked up by another worker:
+
+```js
+...
+var queue = new Queue(ref, function(data, progress, resolve, reject) {
+  ...
+});
+
+process.on('SIGINT', function() {
+  console.log('Starting queue shutdown');
+  queue.shutdown().then(function() {
+    console.log('Finished queue shutdown');
+    process.exit(0);
+  });
+});
+```
+
 ## Message Sanitization, Revisited
 
 In our example at the beginning, you wanted to perform several actions on your chat system:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,4 @@
+changed - `Queue` constructor returns the instantiated queue instead of a promise
+feature - Graceful shutdown of a queue is now possible using the instantiated object's `shutdown()` method
+feature - Synchronously thrown errors in a `processingFunction` are now caught and passed to the `reject()` handler
+changed - All logging is now at Winston's `debug` level to reduce log pollution

--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
     "README.md",
     "package.json"
   ],
+  "peerDependencies": {
+    "firebase": "2.x"
+  },
   "dependencies": {
-    "firebase": "2.x",
     "lodash": "~3.7.0",
     "rsvp": "3.x",
     "node-uuid": "1.4.x",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "firebase": "2.x"
   },
   "dependencies": {
+    "firebase": "2.x",
     "lodash": "~3.7.0",
     "rsvp": "3.x",
     "node-uuid": "1.4.x",

--- a/src/lib/queue_worker.js
+++ b/src/lib/queue_worker.js
@@ -22,22 +22,22 @@ function QueueWorker(tasksRef, processId, sanitize, processingFunction) {
       error;
   if (_.isUndefined(tasksRef)) {
     error = 'No tasks reference provided.';
-    logger.error('QueueWorker(): ' + error);
+    logger.debug('QueueWorker(): ' + error);
     throw new Error(error);
   }
   if (!_.isString(processId)) {
     error = 'Invalid process ID provided.';
-    logger.error('QueueWorker(): ' + error);
+    logger.debug('QueueWorker(): ' + error);
     throw new Error(error);
   }
   if (!_.isBoolean(sanitize)) {
     error = 'Invalid sanitize option.';
-    logger.error('QueueWorker(): ' + error);
+    logger.debug('QueueWorker(): ' + error);
     throw new Error(error);
   }
   if (!_.isFunction(processingFunction)) {
     error = 'No processing function provided.';
-    logger.error('QueueWorker(): ' + error);
+    logger.debug('QueueWorker(): ' + error);
     throw new Error(error);
   }
 
@@ -108,16 +108,16 @@ QueueWorker.prototype._resetTask = function(taskRef, deferred) {
     /* istanbul ignore if */
     if (error) {
       if (++retries < MAX_TRANSACTION_ATTEMPTS) {
-        logger.warn(self._getLogEntry('reset task errored, retrying'), error);
+        logger.debug(self._getLogEntry('reset task errored, retrying'), error);
         setImmediate(self._resetTask.bind(self), taskRef, deferred);
       } else {
         var errorMsg = 'reset task errored too many times, no longer retrying';
-        logger.error(self._getLogEntry(errorMsg), error);
+        logger.debug(self._getLogEntry(errorMsg), error);
         deferred.reject(errorMsg);
       }
     } else {
       if (committed && snapshot.exists()) {
-        logger.info(self._getLogEntry('reset ' + snapshot.key()));
+        logger.debug(self._getLogEntry('reset ' + snapshot.key()));
       }
       deferred.resolve();
     }
@@ -145,10 +145,10 @@ QueueWorker.prototype._resolve = function(taskNumber) {
 
     if ((taskNumber !== self.taskNumber) || _.isNull(self.currentTaskRef)) {
       if (_.isNull(self.currentTaskRef)) {
-        logger.warn(self._getLogEntry('Can\'t resolve task - no task ' +
+        logger.debug(self._getLogEntry('Can\'t resolve task - no task ' +
           'currently being processed'));
       } else {
-        logger.warn(self._getLogEntry('Can\'t resolve task - no longer ' +
+        logger.debug(self._getLogEntry('Can\'t resolve task - no longer ' +
           'processing current task'));
       }
       deferred.resolve();
@@ -184,21 +184,21 @@ QueueWorker.prototype._resolve = function(taskNumber) {
         /* istanbul ignore if */
         if (error) {
           if (++retries < MAX_TRANSACTION_ATTEMPTS) {
-            logger.warn(self._getLogEntry('resolve task errored, retrying'),
+            logger.debug(self._getLogEntry('resolve task errored, retrying'),
               error);
             setImmediate(resolve, newTask);
           } else {
             var errorMsg = 'resolve task errored too many times, no longer ' +
               'retrying';
-            logger.error(self._getLogEntry(errorMsg), error);
+            logger.debug(self._getLogEntry(errorMsg), error);
             deferred.reject(errorMsg);
           }
         } else {
           if (committed && existedBefore) {
-            logger.info(self._getLogEntry('completed ' + snapshot.key()));
+            logger.debug(self._getLogEntry('completed ' + snapshot.key()));
           } else {
-            logger.warn(self._getLogEntry('Can\'t resolve task - current task' +
-                ' no longer owned by this process'));
+            logger.debug(self._getLogEntry('Can\'t resolve task - current ' +
+              'task no longer owned by this process'));
           }
           deferred.resolve();
           self.busy = false;
@@ -234,10 +234,10 @@ QueueWorker.prototype._reject = function(taskNumber) {
 
     if ((taskNumber !== self.taskNumber) || _.isNull(self.currentTaskRef)) {
       if (_.isNull(self.currentTaskRef)) {
-        logger.warn(self._getLogEntry('Can\'t reject task - no task currently' +
-          ' being processed'));
+        logger.debug(self._getLogEntry('Can\'t reject task - no task ' +
+          'currently being processed'));
       } else {
-        logger.warn(self._getLogEntry('Can\'t reject task - no longer ' +
+        logger.debug(self._getLogEntry('Can\'t reject task - no longer ' +
           'processing current task'));
       }
       deferred.resolve();
@@ -278,22 +278,22 @@ QueueWorker.prototype._reject = function(taskNumber) {
         /* istanbul ignore if */
         if (error) {
           if (++retries < MAX_TRANSACTION_ATTEMPTS) {
-            logger.warn(self._getLogEntry('reject task errored, retrying'),
+            logger.debug(self._getLogEntry('reject task errored, retrying'),
               error);
             setImmediate(reject, error);
           } else {
             var errorMsg = 'reject task errored too many times, no longer ' +
               'retrying';
-            logger.error(self._getLogEntry(errorMsg), error);
+            logger.debug(self._getLogEntry(errorMsg), error);
             deferred.reject(errorMsg);
           }
         } else {
           if (committed && existedBefore) {
-            logger.error(self._getLogEntry('errored while attempting to ' +
+            logger.debug(self._getLogEntry('errored while attempting to ' +
               'complete ' + snapshot.key()));
           } else {
-            logger.warn(self._getLogEntry('Can\'t reject task - current task ' +
-              'no longer owned by this process'));
+            logger.debug(self._getLogEntry('Can\'t reject task - current task' +
+              ' no longer owned by this process'));
           }
           deferred.resolve();
           self.busy = false;
@@ -330,7 +330,7 @@ QueueWorker.prototype._updateProgress = function(taskNumber) {
     }
     if ((taskNumber !== self.taskNumber)  || _.isNull(self.currentTaskRef)) {
       errorMsg = 'Can\'t update progress - no task currently being processed';
-      logger.warn(self._getLogEntry(errorMsg));
+      logger.debug(self._getLogEntry(errorMsg));
       return RSVP.reject(errorMsg);
     }
     return new RSVP.Promise(function(resolve, reject) {
@@ -351,7 +351,7 @@ QueueWorker.prototype._updateProgress = function(taskNumber) {
         /* istanbul ignore if */
         if (error) {
           errorMsg = 'errored while attempting to update progress';
-          logger.error(self._getLogEntry(errorMsg), error);
+          logger.debug(self._getLogEntry(errorMsg), error);
           return reject(errorMsg);
         }
         if (committed && snapshot.exists()) {
@@ -359,7 +359,7 @@ QueueWorker.prototype._updateProgress = function(taskNumber) {
         } else {
           errorMsg = 'Can\'t update progress - current task no longer owned ' +
             'by this process';
-          logger.warn(self._getLogEntry(errorMsg));
+          logger.debug(self._getLogEntry(errorMsg));
           return reject(errorMsg);
         }
       }, false);
@@ -388,7 +388,7 @@ QueueWorker.prototype._tryToProcess = function(nextTaskRef, deferred) {
     if (!_.isNull(self.shutdownDeffered)) {
       deferred.reject('Shutting down - can no longer process new tasks');
       self.setTaskSpec(null);
-      logger.info(self._getLogEntry('finished shutdown'));
+      logger.debug(self._getLogEntry('finished shutdown'));
       self.shutdownDeffered.resolve();
     } else {
       nextTaskRef.transaction(function(task) {
@@ -423,19 +423,19 @@ QueueWorker.prototype._tryToProcess = function(nextTaskRef, deferred) {
         /* istanbul ignore if */
         if (error) {
           if (++retries < MAX_TRANSACTION_ATTEMPTS) {
-            logger.warn(self._getLogEntry('errored while attempting to claim ' +
-              'a new task, retrying'), error);
+            logger.debug(self._getLogEntry('errored while attempting to claim' +
+              ' a new task, retrying'), error);
             return setImmediate(self._tryToProcess.bind(self), nextTaskRef,
               deferred);
           } else {
             var errorMsg = 'errored while attempting to claim a new task too ' +
               'many times, no longer retrying';
-            logger.error(self._getLogEntry(errorMsg), error);
+            logger.debug(self._getLogEntry(errorMsg), error);
             return deferred.reject(errorMsg);
           }
         } else if (committed && snapshot.exists()) {
           if (malformed) {
-            logger.warn(self._getLogEntry('found malformed entry ' +
+            logger.debug(self._getLogEntry('found malformed entry ' +
               snapshot.key()));
           } else {
             /* istanbul ignore if */
@@ -446,7 +446,7 @@ QueueWorker.prototype._tryToProcess = function(nextTaskRef, deferred) {
             } else {
               self.busy = true;
               self.taskNumber += 1;
-              logger.info(self._getLogEntry('claimed ' + snapshot.key()));
+              logger.debug(self._getLogEntry('claimed ' + snapshot.key()));
               self.currentTaskRef = snapshot.ref();
               self.currentTaskListener = self.currentTaskRef
                   .child('_owner').on('value', function(ownerSnapshot) {
@@ -541,7 +541,7 @@ QueueWorker.prototype._setUpTimeouts = function() {
     self.processingTaskAddedListener = self.processingTasksRef.on('child_added',
       setUpTimeout,
       /* istanbul ignore next */ function(error) {
-        logger.warn(self._getLogEntry('errored listening to Firebase'), error);
+        logger.debug(self._getLogEntry('errored listening to Firebase'), error);
       });
     self.processingTaskRemovedListener = self.processingTasksRef.on(
       'child_removed',
@@ -551,7 +551,7 @@ QueueWorker.prototype._setUpTimeouts = function() {
         delete self.expiryTimeouts[taskName];
         delete self.owners[taskName];
       }, /* istanbul ignore next */ function(error) {
-        logger.warn(self._getLogEntry('errored listening to Firebase'), error);
+        logger.debug(self._getLogEntry('errored listening to Firebase'), error);
       });
     self.processingTasksRef.on('child_changed', function(snapshot) {
       // This catches de-duped events from the server - if the task was removed
@@ -562,7 +562,7 @@ QueueWorker.prototype._setUpTimeouts = function() {
         setUpTimeout(snapshot);
       }
     }, /* istanbul ignore next */ function(error) {
-      logger.warn(self._getLogEntry('errored listening to Firebase'), error);
+      logger.debug(self._getLogEntry('errored listening to Firebase'), error);
     });
   } else {
     self.processingTasksRef = null;
@@ -664,17 +664,17 @@ QueueWorker.prototype.setTaskSpec = function(taskSpec) {
                           .orderByChild('_state')
                           .equalTo(self.startState)
                           .limitToFirst(1);
-    logger.info(self._getLogEntry('listening'));
+    logger.debug(self._getLogEntry('listening'));
     self.newTaskListener = self.newTaskRef.on(
       'child_added',
       function(snapshot) {
         self.nextTaskRef = snapshot.ref();
         self._tryToProcess(self.nextTaskRef);
       }, /* istanbul ignore next */ function(error) {
-        logger.warn(self._getLogEntry('errored listening to Firebase'), error);
+        logger.debug(self._getLogEntry('errored listening to Firebase'), error);
       });
   } else {
-    logger.error(self._getLogEntry('invalid task spec, not listening for new ' +
+    logger.debug(self._getLogEntry('invalid task spec, not listening for new ' +
       'tasks'));
     self.startState = null;
     self.inProgressState = null;
@@ -693,7 +693,7 @@ QueueWorker.prototype.setTaskSpec = function(taskSpec) {
 QueueWorker.prototype.shutdown = function() {
   var self = this;
 
-  logger.info(self._getLogEntry('shutting down'));
+  logger.debug(self._getLogEntry('shutting down'));
 
   // Set the global shutdown deferred promise, which signals we're shutting down
   self.shutdownDeffered = RSVP.defer();
@@ -701,7 +701,7 @@ QueueWorker.prototype.shutdown = function() {
   // We can report success immediately if we're not busy
   if (!self.busy) {
     self.setTaskSpec(null);
-    logger.info(self._getLogEntry('finished shutdown'));
+    logger.debug(self._getLogEntry('finished shutdown'));
     self.shutdownDeffered.resolve();
   }
 

--- a/src/lib/queue_worker.js
+++ b/src/lib/queue_worker.js
@@ -476,13 +476,17 @@ QueueWorker.prototype._tryToProcess = function(nextTaskRef, deferred) {
                   }
                 });
               }
-              setImmediate(
-                self.processingFunction,
-                data,
-                self._updateProgress(self.taskNumber),
-                self._resolve(self.taskNumber),
-                self._reject(self.taskNumber)
-              );
+              var progress = self._updateProgress(self.taskNumber);
+              var resolve = self._resolve(self.taskNumber);
+              var reject = self._reject(self.taskNumber);
+              setImmediate(function() {
+                try {
+                  self.processingFunction.call(null, data, progress, resolve,
+                    reject);
+                } catch (error) {
+                  reject(error.message);
+                }
+              });
             }
           }
         }

--- a/src/queue.js
+++ b/src/queue.js
@@ -62,7 +62,7 @@ function Queue() {
   if (constructorArguments.length < 2) {
     error = 'Queue must at least have the queueRef and ' +
       'processingFunction arguments.';
-    logger.error('Queue(): Error during initialization', error);
+    logger.debug('Queue(): Error during initialization', error);
     throw new Error(error);
   } else if (constructorArguments.length === 2) {
     self.ref = constructorArguments[0];
@@ -72,7 +72,7 @@ function Queue() {
     var options = constructorArguments[1];
     if (!_.isPlainObject(options)) {
       error = 'Options parameter must be a plain object.';
-      logger.error('Queue(): Error during initialization', error);
+      logger.debug('Queue(): Error during initialization', error);
       throw new Error(error);
     }
     if (!_.isUndefined(options.specId)) {
@@ -80,7 +80,7 @@ function Queue() {
         self.specId = options.specId;
       } else {
         error = 'options.specId must be a String.';
-        logger.error('Queue(): Error during initialization', error);
+        logger.debug('Queue(): Error during initialization', error);
         throw new Error(error);
       }
     }
@@ -91,7 +91,7 @@ function Queue() {
         self.numWorkers = options.numWorkers;
       } else {
         error = 'options.numWorkers must be a positive integer.';
-        logger.error('Queue(): Error during initialization', error);
+        logger.debug('Queue(): Error during initialization', error);
         throw new Error(error);
       }
     }
@@ -100,7 +100,7 @@ function Queue() {
         self.sanitize = options.sanitize;
       } else {
         error = 'options.sanitize must be a boolean.';
-        logger.error('Queue(): Error during initialization', error);
+        logger.debug('Queue(): Error during initialization', error);
         throw new Error(error);
       }
     }
@@ -108,7 +108,7 @@ function Queue() {
   } else {
     error = 'Queue can only take at most three arguments - queueRef, ' +
       'options (optional), and processingFunction.';
-    logger.error('Queue(): Error during initialization', error);
+    logger.debug('Queue(): Error during initialization', error);
     throw new Error(error);
   }
 
@@ -146,7 +146,7 @@ function Queue() {
         }
         self.initialized = true;
       }, /* istanbul ignore next */ function(error) {
-        logger.error('Queue(): Error connecting to Firebase reference',
+        logger.debug('Queue(): Error connecting to Firebase reference',
           error.message);
       });
   }
@@ -163,7 +163,7 @@ function Queue() {
 Queue.prototype.shutdown = function() {
   var self = this;
 
-  logger.info('Queue: Shutting down');
+  logger.debug('Queue: Shutting down');
   if (!_.isNull(self.specChangeListener)) {
     self.ref.child('specs').child(self.specId).off('value',
       self.specChangeListener);

--- a/test/lib/queue_worker.spec.js
+++ b/test/lib/queue_worker.spec.js
@@ -983,6 +983,54 @@ describe('QueueWorker', function() {
       });
     });
 
+    it('should try and process a task if not busy, rejecting it if it throws', function(done) {
+      qw = new th.QueueWorker(tasksRef, '0', true, function(data, progress, resolve, reject) {
+        throw new Error('Error thrown in processingFunction');
+      });
+      qw.startState = th.validTaskSpecWithStartState.startState;
+      qw.inProgressState = th.validTaskSpecWithStartState.inProgressState;
+      qw.finishedState = th.validTaskSpecWithFinishedState.finishedState;
+      qw.taskRetries = 0;
+      var testRef = tasksRef.push({
+        '_state': th.validTaskSpecWithStartState.startState
+      }, function(errorA) {
+        if (errorA) {
+          return done(errorA);
+        }
+        qw.nextTaskRef = testRef;
+        qw._tryToProcess(testRef).then(function() {
+          try {
+            expect(qw.currentTaskRef).to.not.be.null;
+            expect(qw.busy).to.be.true;
+            var initial = true;
+            testRef.on('value', function(snapshot) {
+              if (initial) {
+                initial = false;
+              } else {
+                try {
+                  testRef.off();
+                  var task = snapshot.val();
+                  expect(task).to.have.all.keys(['_state', '_progress', '_state_changed', '_error_details']);
+                  expect(task['_state']).to.equal('error');
+                  expect(task['_state_changed']).to.be.closeTo(new Date().getTime() + th.offset, 250);
+                  expect(task['_progress']).to.equal(0);
+                  expect(task['_error_details']).to.have.all.keys(['previous_state', 'attempts', 'error']);
+                  expect(task['_error_details'].previous_state).to.equal(th.validTaskSpecWithStartState.inProgressState);
+                  expect(task['_error_details'].attempts).to.equal(1);
+                  expect(task['_error_details'].error).to.equal('Error thrown in processingFunction');
+                  done();
+                } catch (errorC) {
+                  done(errorC);
+                }
+              }
+            });
+          } catch (errorB) {
+            done(errorB);
+          }
+        }).catch(done);
+      });
+    });
+
     it('should try and process a task without a _state if not busy', function(done) {
       qw.startState = null;
       qw.inProgressState = th.validBasicTaskSpec.inProgressState;

--- a/test/lib/queue_worker.spec.js
+++ b/test/lib/queue_worker.spec.js
@@ -1752,7 +1752,7 @@ describe('QueueWorker', function() {
           } catch (errorB) {
             done(errorB)
           }
-        }, 0);
+        }, 100);
       });
     });
   });

--- a/test/queue.spec.js
+++ b/test/queue.spec.js
@@ -14,77 +14,102 @@ var th = new Helpers();
 
 describe('Queue', function() {
   it('should not create a Queue with only a queue reference', function() {
-    return new th.Queue(th.testRef).should.eventually.be.rejectedWith('Queue must at least have the queueRef and processingFunction arguments.');
+    expect(function() {
+      new th.Queue(th.testRef);
+    }).to.throw('Queue must at least have the queueRef and processingFunction arguments.');
   });
 
   _.forEach(['', 'foo', NaN, Infinity, true, false, 0, 1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }, _.noop], function(nonFirebaseObject) {
     it('should not create a Queue with a non-firebase object: ' + JSON.stringify(nonFirebaseObject), function() {
-      return new th.Queue(nonFirebaseObject, _.noop).should.eventually.be.rejected;
+      expect(function() {
+        new th.Queue(nonFirebaseObject, _.noop);
+      }).to.throw;
     });
   });
 
   _.forEach(['', 'foo', NaN, Infinity, true, false, 0, 1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }], function(nonFunctionObject) {
     it('should not create a Queue with a non-function callback: ' + JSON.stringify(nonFunctionObject), function() {
-      return new th.Queue(th.testRef, nonFunctionObject).should.eventually.be.rejectedWith('No processing function provided.');
+      expect(function() {
+        new th.Queue(th.testRef, nonFunctionObject);
+      }).to.throw('No processing function provided.');
     });
   });
 
   it('should create a default Queue with just a Firebase reference and a processing callback', function() {
-    return new th.Queue(th.testRef, _.noop).should.eventually.be.fulfilled;
+    new th.Queue(th.testRef, _.noop);
   });
 
   _.forEach(['', 'foo', NaN, Infinity, true, false, 0, 1, ['foo', 'bar'], null, _.noop], function(nonPlainObject) {
     it('should not create a Queue with a Firebase reference, a non-plain object options parameter (' + JSON.stringify(nonPlainObject) + '), and a processingCallback', function() {
-      return new th.Queue(th.testRef, nonPlainObject, _.noop).should.eventually.be.rejectedWith('Options parameter must be a plain object.');
+      expect(function() {
+        new th.Queue(th.testRef, nonPlainObject, _.noop);
+      }).to.throw('Options parameter must be a plain object.');
     });
   });
 
   it('should create a default Queue with a Firebase reference, an empty options object, and a processing callback', function() {
-    return new th.Queue(th.testRef, {}, _.noop).should.eventually.be.fulfilled;
+    new th.Queue(th.testRef, {}, _.noop);
   });
 
   _.forEach([NaN, Infinity, true, false, 0, 1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }, _.noop], function(nonStringObject) {
     it('should not create a Queue with a non-string specId specified', function() {
-      return new th.Queue(th.testRef, { specId: nonStringObject }, _.noop).should.eventually.be.rejectedWith('options.specId must be a String.');
+      expect(function() {
+        new th.Queue(th.testRef, { specId: nonStringObject }, _.noop);
+      }).to.throw('options.specId must be a String.');
     });
   });
 
   _.forEach(['', 'foo', NaN, Infinity, true, false, 0, -1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }, _.noop], function(nonPositiveIntigerObject) {
     it('should not create a Queue with a non-positive integer numWorkers specified', function() {
-      return new th.Queue(th.testRef, { numWorkers: nonPositiveIntigerObject }, _.noop).should.eventually.be.rejectedWith('options.numWorkers must be a positive integer.');
+      expect(function() {
+        new th.Queue(th.testRef, { numWorkers: nonPositiveIntigerObject }, _.noop);
+      }).to.throw('options.numWorkers must be a positive integer.');
     });
   });
 
   _.forEach([NaN, Infinity, '', 'foo', 0, 1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }, _.noop], function(nonBooleanObject) {
     it('should not create a Queue with a non-boolean sanitize option specified', function() {
-      return new th.Queue(th.testRef, { sanitize: nonBooleanObject }, _.noop).should.eventually.be.rejectedWith('options.sanitize must be a boolean.');
+      expect(function() {
+        new th.Queue(th.testRef, { sanitize: nonBooleanObject }, _.noop);
+      }).to.throw('options.sanitize must be a boolean.');
     });
   });
 
   _.forEach(_.range(1, 20), function(numWorkers) {
     it('should create a Queue with ' + numWorkers + ' workers when specified in options.numWorkers', function() {
-      return new th.Queue(th.testRef, { numWorkers: numWorkers }, _.noop).then(function(q) {
-        expect(q.workers.length).to.equal(numWorkers);
-      }).should.eventually.be.fulfilled;
+      var q = new th.Queue(th.testRef, { numWorkers: numWorkers }, _.noop);
+      expect(q.workers.length).to.equal(numWorkers);
     });
   });
 
-  it('should create a Queue with a specific specId when specified', function() {
+  it('should create a Queue with a specific specId when specified', function(done) {
     var specId = 'test_task';
-    return new th.Queue(th.testRef, { specId: specId }, _.noop).then(function(q) {
-      expect(q.specId).to.equal(specId);
-    }).should.eventually.be.fulfilled;
+    var q = new th.Queue(th.testRef, { specId: specId }, _.noop);
+    expect(q.specId).to.equal(specId);
+    var interval = setInterval(function() {
+      if (q.initialized) {
+        clearInterval(interval);
+        try {
+          var specRegex = new RegExp('^' + specId + ':0:[a-f0-9\\-]{36}$');
+          expect(q.workers[0].processId).to.match(specRegex);
+          done();
+        } catch(error) {
+          done(error);
+        }
+      }
+    }, 100);
   });
 
   [true, false].forEach(function(bool) {
     it('should create a Queue with a ' + bool + ' sanitize option when specified', function() {
-      return new th.Queue(th.testRef, { sanitize: bool }, _.noop).then(function(q) {
-        expect(q.sanitize).to.equal(bool);
-      }).should.eventually.be.fulfilled;
+      var q = new th.Queue(th.testRef, { sanitize: bool }, _.noop)
+      expect(q.sanitize).to.equal(bool);
     });
   });
 
   it('should not create a Queue when initialized with 4 parameters', function() {
-    return new th.Queue(th.testRef, {}, _.noop, null).should.eventually.be.rejectedWith('Queue can only take at most three arguments - queueRef, options (optional), and processingFunction.');
+    expect(function() {
+      new th.Queue(th.testRef, {}, _.noop, null);
+    }).to.throw('Queue can only take at most three arguments - queueRef, options (optional), and processingFunction.');
   });
 });

--- a/test/queue.spec.js
+++ b/test/queue.spec.js
@@ -13,103 +13,135 @@ chai.use(chaiAsPromised);
 var th = new Helpers();
 
 describe('Queue', function() {
-  it('should not create a Queue with only a queue reference', function() {
-    expect(function() {
-      new th.Queue(th.testRef);
-    }).to.throw('Queue must at least have the queueRef and processingFunction arguments.');
-  });
-
-  _.forEach(['', 'foo', NaN, Infinity, true, false, 0, 1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }, _.noop], function(nonFirebaseObject) {
-    it('should not create a Queue with a non-firebase object: ' + JSON.stringify(nonFirebaseObject), function() {
+  describe('initialize', function() {
+    it('should not create a Queue with only a queue reference', function() {
       expect(function() {
-        new th.Queue(nonFirebaseObject, _.noop);
-      }).to.throw;
+        new th.Queue(th.testRef);
+      }).to.throw('Queue must at least have the queueRef and processingFunction arguments.');
     });
-  });
 
-  _.forEach(['', 'foo', NaN, Infinity, true, false, 0, 1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }], function(nonFunctionObject) {
-    it('should not create a Queue with a non-function callback: ' + JSON.stringify(nonFunctionObject), function() {
-      expect(function() {
-        new th.Queue(th.testRef, nonFunctionObject);
-      }).to.throw('No processing function provided.');
+    _.forEach(['', 'foo', NaN, Infinity, true, false, 0, 1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }, _.noop], function(nonFirebaseObject) {
+      it('should not create a Queue with a non-firebase object: ' + JSON.stringify(nonFirebaseObject), function() {
+        expect(function() {
+          new th.Queue(nonFirebaseObject, _.noop);
+        }).to.throw;
+      });
     });
-  });
 
-  it('should create a default Queue with just a Firebase reference and a processing callback', function() {
-    new th.Queue(th.testRef, _.noop);
-  });
-
-  _.forEach(['', 'foo', NaN, Infinity, true, false, 0, 1, ['foo', 'bar'], null, _.noop], function(nonPlainObject) {
-    it('should not create a Queue with a Firebase reference, a non-plain object options parameter (' + JSON.stringify(nonPlainObject) + '), and a processingCallback', function() {
-      expect(function() {
-        new th.Queue(th.testRef, nonPlainObject, _.noop);
-      }).to.throw('Options parameter must be a plain object.');
+    _.forEach(['', 'foo', NaN, Infinity, true, false, 0, 1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }], function(nonFunctionObject) {
+      it('should not create a Queue with a non-function callback: ' + JSON.stringify(nonFunctionObject), function() {
+        expect(function() {
+          new th.Queue(th.testRef, nonFunctionObject);
+        }).to.throw('No processing function provided.');
+      });
     });
-  });
 
-  it('should create a default Queue with a Firebase reference, an empty options object, and a processing callback', function() {
-    new th.Queue(th.testRef, {}, _.noop);
-  });
-
-  _.forEach([NaN, Infinity, true, false, 0, 1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }, _.noop], function(nonStringObject) {
-    it('should not create a Queue with a non-string specId specified', function() {
-      expect(function() {
-        new th.Queue(th.testRef, { specId: nonStringObject }, _.noop);
-      }).to.throw('options.specId must be a String.');
+    it('should create a default Queue with just a Firebase reference and a processing callback', function() {
+      new th.Queue(th.testRef, _.noop);
     });
-  });
 
-  _.forEach(['', 'foo', NaN, Infinity, true, false, 0, -1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }, _.noop], function(nonPositiveIntigerObject) {
-    it('should not create a Queue with a non-positive integer numWorkers specified', function() {
-      expect(function() {
-        new th.Queue(th.testRef, { numWorkers: nonPositiveIntigerObject }, _.noop);
-      }).to.throw('options.numWorkers must be a positive integer.');
+    _.forEach(['', 'foo', NaN, Infinity, true, false, 0, 1, ['foo', 'bar'], null, _.noop], function(nonPlainObject) {
+      it('should not create a Queue with a Firebase reference, a non-plain object options parameter (' + JSON.stringify(nonPlainObject) + '), and a processingCallback', function() {
+        expect(function() {
+          new th.Queue(th.testRef, nonPlainObject, _.noop);
+        }).to.throw('Options parameter must be a plain object.');
+      });
     });
-  });
 
-  _.forEach([NaN, Infinity, '', 'foo', 0, 1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }, _.noop], function(nonBooleanObject) {
-    it('should not create a Queue with a non-boolean sanitize option specified', function() {
-      expect(function() {
-        new th.Queue(th.testRef, { sanitize: nonBooleanObject }, _.noop);
-      }).to.throw('options.sanitize must be a boolean.');
+    it('should create a default Queue with a Firebase reference, an empty options object, and a processing callback', function() {
+      new th.Queue(th.testRef, {}, _.noop);
     });
-  });
 
-  _.forEach(_.range(1, 20), function(numWorkers) {
-    it('should create a Queue with ' + numWorkers + ' workers when specified in options.numWorkers', function() {
-      var q = new th.Queue(th.testRef, { numWorkers: numWorkers }, _.noop);
-      expect(q.workers.length).to.equal(numWorkers);
+    _.forEach([NaN, Infinity, true, false, 0, 1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }, _.noop], function(nonStringObject) {
+      it('should not create a Queue with a non-string specId specified', function() {
+        expect(function() {
+          new th.Queue(th.testRef, { specId: nonStringObject }, _.noop);
+        }).to.throw('options.specId must be a String.');
+      });
     });
-  });
 
-  it('should create a Queue with a specific specId when specified', function(done) {
-    var specId = 'test_task';
-    var q = new th.Queue(th.testRef, { specId: specId }, _.noop);
-    expect(q.specId).to.equal(specId);
-    var interval = setInterval(function() {
-      if (q.initialized) {
-        clearInterval(interval);
-        try {
-          var specRegex = new RegExp('^' + specId + ':0:[a-f0-9\\-]{36}$');
-          expect(q.workers[0].processId).to.match(specRegex);
-          done();
-        } catch(error) {
-          done(error);
+    _.forEach(['', 'foo', NaN, Infinity, true, false, 0, -1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }, _.noop], function(nonPositiveIntigerObject) {
+      it('should not create a Queue with a non-positive integer numWorkers specified', function() {
+        expect(function() {
+          new th.Queue(th.testRef, { numWorkers: nonPositiveIntigerObject }, _.noop);
+        }).to.throw('options.numWorkers must be a positive integer.');
+      });
+    });
+
+    _.forEach([NaN, Infinity, '', 'foo', 0, 1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }, _.noop], function(nonBooleanObject) {
+      it('should not create a Queue with a non-boolean sanitize option specified', function() {
+        expect(function() {
+          new th.Queue(th.testRef, { sanitize: nonBooleanObject }, _.noop);
+        }).to.throw('options.sanitize must be a boolean.');
+      });
+    });
+
+    _.forEach(_.range(1, 20), function(numWorkers) {
+      it('should create a Queue with ' + numWorkers + ' workers when specified in options.numWorkers', function() {
+        var q = new th.Queue(th.testRef, { numWorkers: numWorkers }, _.noop);
+        expect(q.workers.length).to.equal(numWorkers);
+      });
+    });
+
+    it('should create a Queue with a specific specId when specified', function(done) {
+      var specId = 'test_task';
+      var q = new th.Queue(th.testRef, { specId: specId }, _.noop);
+      expect(q.specId).to.equal(specId);
+      var interval = setInterval(function() {
+        if (q.initialized) {
+          clearInterval(interval);
+          try {
+            var specRegex = new RegExp('^' + specId + ':0:[a-f0-9\\-]{36}$');
+            expect(q.workers[0].processId).to.match(specRegex);
+            done();
+          } catch(error) {
+            done(error);
+          }
         }
-      }
-    }, 100);
-  });
+      }, 100);
+    });
 
-  [true, false].forEach(function(bool) {
-    it('should create a Queue with a ' + bool + ' sanitize option when specified', function() {
-      var q = new th.Queue(th.testRef, { sanitize: bool }, _.noop)
-      expect(q.sanitize).to.equal(bool);
+    [true, false].forEach(function(bool) {
+      it('should create a Queue with a ' + bool + ' sanitize option when specified', function() {
+        var q = new th.Queue(th.testRef, { sanitize: bool }, _.noop)
+        expect(q.sanitize).to.equal(bool);
+      });
+    });
+
+    it('should not create a Queue when initialized with 4 parameters', function() {
+      expect(function() {
+        new th.Queue(th.testRef, {}, _.noop, null);
+      }).to.throw('Queue can only take at most three arguments - queueRef, options (optional), and processingFunction.');
     });
   });
 
-  it('should not create a Queue when initialized with 4 parameters', function() {
-    expect(function() {
-      new th.Queue(th.testRef, {}, _.noop, null);
-    }).to.throw('Queue can only take at most three arguments - queueRef, options (optional), and processingFunction.');
+  describe('#shutdown', function() {
+    var q;
+
+    it('should shutdown a queue initialized with the default spec', function() {
+      q = new th.Queue(th.testRef, _.noop);
+      return q.shutdown().should.eventually.be.fulfilled;
+    });
+
+    it('should shutdown a queue initialized with a custom spec before the listener callback', function() {
+      q = new th.Queue(th.testRef, { specId: 'test_task' }, _.noop);
+      return q.shutdown().should.eventually.be.fulfilled;
+    });
+
+    it('should shutdown a queue initialized with a custom spec after the listener callback', function(done) {
+      q = new th.Queue(th.testRef, { specId: 'test_task' }, _.noop);
+      var interval = setInterval(function() {
+        if (q.initialized) {
+          clearInterval(interval);
+          try {
+            var shutdownPromise = q.shutdown();
+            expect(q.specChangeListener).to.be.null;
+            shutdownPromise.should.eventually.be.fulfilled.notify(done);
+          } catch (error) {
+            done(error);
+          }
+        }
+      }, 100);
+    });
   });
 });


### PR DESCRIPTION
Changes the constructor to return an actual Queue object instead of a promise (which was weird, this is much more idiomatic), and adds a `shutdown()` method to the returned object that gracefully shuts down all workers before resolving the promise that it returns (as per #13). This technically changes how the constructor behaves, but I doubt anyone's using the (undocumented) promise it used to return, so I think just a minor version bump is right

/cc @mcdonamp 