### PR TITLE
v1.2.0 release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ A callback function for reporting that the current task has been completed and t
 
 #### `reject()`
 
-A callback function for reporting that the current task failed and the worker is ready to process another task. Once this is called, the task will go into the `error_state` for the job with an additional `_error_details` object containing a `previous_state` key referencing this task's `in_progress_state`. If a string is passed into the `reject()` function, the `_error_details` will also contain an `error` key containing that string. If an error is passed into the `reject()` function, the `error` key will contain the `error.message` and the `error_stack` key will contain the `error.stack`, unless the `suppressStack` option has been specified for the queue. Note that if retries are enabled and there are remaining attempts, the task will be restarted in it's spec's `start_state`.
+A callback function for reporting that the current task failed and the worker is ready to process another task. Once this is called, the task will go into the `error_state` for the job with an additional `_error_details` object containing a `previous_state` key referencing this task's `in_progress_state`. If a string is passed into the `reject()` function, the `_error_details` will also contain an `error` key containing that string. If an Error is passed into the `reject()` function, the `error` key will contain the `error.message`, and if `suppressStack` option has not been specified the `error_stack` key will contain the `error.stack`. Note that if retries are enabled and there are remaining attempts, the task will be restarted in it's spec's `start_state`.
 
 ## Queue Security
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ These don't have to use a custom token, for instance you could use `auth != null
               "error": {
                 ".validate": "newData.isString()"
               },
+              "error_stack": {
+                ".validate": "newData.isString()"
+              },
               "previous_state": {
                 ".validate": "newData.isString()"
               },

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,2 @@
+feature - Better error handling, including the ability to handle Error objects in the `reject()` callback function
+feature - Reporting Error stacktraces in the `_error_details` of a task, unless the `suppressStack` queue option is specified

--- a/src/lib/queue_worker.js
+++ b/src/lib/queue_worker.js
@@ -17,7 +17,7 @@ var MAX_TRANSACTION_ATTEMPTS = 10,
  *   task is claimed.
  * @return {Object}
  */
-function QueueWorker(tasksRef, processId, sanitize, processingFunction) {
+function QueueWorker(tasksRef, processId, sanitize, suppressStack, processingFunction) {
   var self = this,
       error;
   if (_.isUndefined(tasksRef)) {
@@ -32,6 +32,11 @@ function QueueWorker(tasksRef, processId, sanitize, processingFunction) {
   }
   if (!_.isBoolean(sanitize)) {
     error = 'Invalid sanitize option.';
+    logger.debug('QueueWorker(): ' + error);
+    throw new Error(error);
+  }
+  if (!_.isBoolean(suppressStack)) {
+    error = 'Invalid suppressStack option.';
     logger.debug('QueueWorker(): ' + error);
     throw new Error(error);
   }
@@ -62,6 +67,7 @@ function QueueWorker(tasksRef, processId, sanitize, processingFunction) {
   self.taskNumber = 0;
   self.errorState = DEFAULT_ERROR_STATE;
   self.sanitize = sanitize;
+  self.suppressStack = suppressStack;
 
   return self;
 }

--- a/src/queue.js
+++ b/src/queue.js
@@ -15,6 +15,7 @@ var _ = require('lodash'),
 
 var DEFAULT_NUM_WORKERS = 1,
     DEFAULT_SANITIZE = true,
+    DEFAULT_SUPPRESS_STACK = false,
     DEFAULT_TASK_SPEC = {
       inProgressState: 'in_progress',
       timeout: 300000 // 5 minutes
@@ -55,6 +56,7 @@ function Queue() {
   var error;
   self.numWorkers = DEFAULT_NUM_WORKERS;
   self.sanitize = DEFAULT_SANITIZE;
+  self.suppressStack = DEFAULT_SUPPRESS_STACK;
   self.initialized = false;
 
   self.specChangeListener = null;
@@ -104,6 +106,15 @@ function Queue() {
         throw new Error(error);
       }
     }
+    if (!_.isUndefined(options.suppressStack)) {
+      if (_.isBoolean(options.suppressStack)) {
+        self.suppressStack = options.suppressStack;
+      } else {
+        error = 'options.suppressStack must be a boolean.';
+        logger.debug('Queue(): Error during initialization', error);
+        throw new Error(error);
+      }
+    }
     self.processingFunction = constructorArguments[2];
   } else {
     error = 'Queue can only take at most three arguments - queueRef, ' +
@@ -119,6 +130,7 @@ function Queue() {
       self.ref.child('tasks'),
       processId,
       self.sanitize,
+      self.suppressStack,
       self.processingFunction
     ));
   }

--- a/test/lib/queue_worker.spec.js
+++ b/test/lib/queue_worker.spec.js
@@ -563,6 +563,7 @@ describe('QueueWorker', function() {
           } else {
             try {
               var task = snapshot.val();
+              console.log('$$', task);
               expect(task).to.have.all.keys(['_progress', '_state_changed', '_error_details']);
               expect(task['_state_changed']).to.be.closeTo(new Date().getTime() + th.offset, 250);
               expect(task['_progress']).to.equal(0);
@@ -641,7 +642,7 @@ describe('QueueWorker', function() {
                 expect(task['_state']).to.equal('error');
                 expect(task['_state_changed']).to.be.closeTo(new Date().getTime() + th.offset, 250);
                 expect(task['_progress']).to.equal(0);
-                expect(task['_error_details']).to.have.all.keys(['previous_state', 'error', 'attempts']);
+                expect(task['_error_details']).to.have.all.keys(['previous_state', 'error', 'attempts', 'error_stack']);
                 expect(task['_error_details'].previous_state).to.equal(th.validBasicTaskSpec.inProgressState);
                 expect(task['_error_details'].error).to.equal(nonStringObject.toString());
                 expect(task['_error_details'].attempts).to.equal(1);
@@ -657,7 +658,7 @@ describe('QueueWorker', function() {
 
     it('should reject a task owned by the current worker and append the error string to the _error_details', function(done) {
       qw = new th.QueueWorkerWithoutProcessingOrTimeouts(tasksRef, '0', true, _.noop);
-      var error = 'My error message';
+      var error = new Error('My error message');
       qw.setTaskSpec(th.validBasicTaskSpec);
       testRef = tasksRef.push({
         '_state': th.validBasicTaskSpec.inProgressState,
@@ -681,10 +682,10 @@ describe('QueueWorker', function() {
               expect(task['_state']).to.equal('error');
               expect(task['_state_changed']).to.be.closeTo(new Date().getTime() + th.offset, 250);
               expect(task['_progress']).to.equal(0);
-              expect(task['_error_details']).to.have.all.keys(['previous_state', 'error', 'attempts']);
+              expect(task['_error_details']).to.have.all.keys(['previous_state', 'error', 'attempts', 'error_stack']);
               expect(task['_error_details'].previous_state).to.equal(th.validBasicTaskSpec.inProgressState);
               expect(task['_error_details'].attempts).to.equal(1);
-              expect(task['_error_details'].error).to.equal(error);
+              expect(task['_error_details'].error).to.equal(error.message);
               done();
             } catch (errorB) {
               done(errorB);
@@ -1014,7 +1015,7 @@ describe('QueueWorker', function() {
                   expect(task['_state']).to.equal('error');
                   expect(task['_state_changed']).to.be.closeTo(new Date().getTime() + th.offset, 250);
                   expect(task['_progress']).to.equal(0);
-                  expect(task['_error_details']).to.have.all.keys(['previous_state', 'attempts', 'error']);
+                  expect(task['_error_details']).to.have.all.keys(['previous_state', 'attempts', 'error', 'error_stack']);
                   expect(task['_error_details'].previous_state).to.equal(th.validTaskSpecWithStartState.inProgressState);
                   expect(task['_error_details'].attempts).to.equal(1);
                   expect(task['_error_details'].error).to.equal('Error thrown in processingFunction');

--- a/test/queue.spec.js
+++ b/test/queue.spec.js
@@ -76,6 +76,14 @@ describe('Queue', function() {
       });
     });
 
+    _.forEach([NaN, Infinity, '', 'foo', 0, 1, ['foo', 'bar'], { foo: 'bar' }, null, { foo: 'bar' }, { foo: { bar: { baz: true } } }, _.noop], function(nonBooleanObject) {
+      it('should not create a Queue with a non-boolean suppressStack option specified', function() {
+        expect(function() {
+          new th.Queue(th.testRef, { suppressStack: nonBooleanObject }, _.noop);
+        }).to.throw('options.suppressStack must be a boolean.');
+      });
+    });
+
     _.forEach(_.range(1, 20), function(numWorkers) {
       it('should create a Queue with ' + numWorkers + ' workers when specified in options.numWorkers', function() {
         var q = new th.Queue(th.testRef, { numWorkers: numWorkers }, _.noop);
@@ -105,6 +113,13 @@ describe('Queue', function() {
       it('should create a Queue with a ' + bool + ' sanitize option when specified', function() {
         var q = new th.Queue(th.testRef, { sanitize: bool }, _.noop)
         expect(q.sanitize).to.equal(bool);
+      });
+    });
+
+    [true, false].forEach(function(bool) {
+      it('should create a Queue with a ' + bool + ' suppressStack option when specified', function() {
+        var q = new th.Queue(th.testRef, { suppressStack: bool }, _.noop)
+        expect(q.suppressStack).to.equal(bool);
       });
     });
 


### PR DESCRIPTION
Changes to the way error objects are handled by the `reject()` callback function and adding an option to suppress storing stack traces in the task's database location for security reasons

/cc @dreadjr