### PR TITLE
Use new Travis infra and run against latest stable Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
 - '0.10'
 - '0.12'
+- stable
+sudo: false
 install:
 - npm install
 script:


### PR DESCRIPTION
See [here](http://docs.travis-ci.com/user/migrating-from-legacy) for details on the new Travis infrastructure.

As a sanity check, we should run the CI tests against latest stable Node, especially as they move to a faster release cycle.