### PR TITLE
Fix potential bug in docs examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ var options = {
   'specId': 'fanout_message',
   'numWorkers': 5
 };
-var fanoutQueue = new Queue(tasksRef, options, function(data, progress, resolve, reject) {
+var fanoutQueue = new Queue(queueRef, options, function(data, progress, resolve, reject) {
   // fan data out to /messages; ensure that errors are caught and cause the task to fail
   messagesRef.push(data, function(error){
     if (error) {


### PR DESCRIPTION
When I have my first Queue instance be using queueRef and my second Queue instance be using tasksRef (like it is in the docs), the second spec never runs. However, if both Queues are using queueRef, it works as expected.