### PR TITLE
Give access to task ID to the worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The reserved keys are:
  - `_owner` - A unique ID for the worker and task number combination to ensure only one worker is responsible for the task at any time.
  - `_progress` - A number between 0 and 100, reset at the start of each task to 0.
  - `_error_details` - An object containing the error details from a previous task execution. If present, it may contain a `previous_state` string (or `null` if there was no previous state, in the case of malformed input) capturing the state the task was in when it errored, an `error` string from the `reject()` callback of the previous task, and an `attempts` field containing the number of retries attempted before failing a task. If the `suppressStack` queue option is not set to `true`, there may also be a `error_stack` field containg a stack dump of any error passed into the `reject()` function.
+ - `_id` - The Firebase key of the task.
 
  By default the data is sanitized of these keys, but you can disable this behavior by setting `'sanitize': false` in the [queue options](#queue-worker-options-optional).
 
@@ -228,6 +229,9 @@ These don't have to use a custom token, for instance you could use `auth != null
               "$other": {
                 ".validate": false
               }
+          },
+          "_id": {
+            ".validate": "newData.isString()"
           },
           "property_1": {
             ".validate": "/* Insert custom data validation code here */"
@@ -434,6 +438,7 @@ root
         - _progress: 0
         - _state: "sanitize_message_in_progress"
         - _state_changed: 1431475215737
+        - _id: $taskId
         - message: "Hello Firebase Queue Users!"
         - name: "Chris"
 ```
@@ -451,6 +456,7 @@ root
         - _progress: 100
         - _state: "sanitize_message_finished"
         - _state_changed: 1431475215918
+        - _id: $taskId
         - message: "Hello Firebase ***** Users!"
         - name: "Chris"
 ```

--- a/src/lib/queue_worker.js
+++ b/src/lib/queue_worker.js
@@ -436,6 +436,7 @@ QueueWorker.prototype._tryToProcess = function(nextTaskRef, deferred) {
             }
           };
         }
+        task._id = nextTaskRef.key();
         if (_.isUndefined(task._state)) {
           task._state = null;
         }
@@ -498,7 +499,8 @@ QueueWorker.prototype._tryToProcess = function(nextTaskRef, deferred) {
                   '_state_changed',
                   '_owner',
                   '_progress',
-                  '_error_details'
+                  '_error_details',
+                  '_id'
                 ].forEach(function(reserved) {
                   if (snapshot.hasChild(reserved)) {
                     delete data[reserved];

--- a/test/lib/queue_worker.spec.js
+++ b/test/lib/queue_worker.spec.js
@@ -1138,7 +1138,7 @@ describe('QueueWorker', function() {
                 try {
                   testRef.off();
                   var task = snapshot.val();
-                  expect(task).to.have.all.keys(['_state', '_progress', '_state_changed', '_error_details']);
+                  expect(task).to.have.all.keys(['_state', '_progress', '_state_changed', '_error_details', '_id']);
                   expect(task['_state']).to.equal('error');
                   expect(task['_state_changed']).to.be.closeTo(new Date().getTime() + th.offset, 250);
                   expect(task['_progress']).to.equal(0);
@@ -1314,7 +1314,7 @@ describe('QueueWorker', function() {
     it('should not sanitize data passed to the processing function when specified', function(done) {
       qw = new th.QueueWorker(tasksRef, '0', false, false, function(data, progress, resolve, reject) {
         try {
-          expect(data).to.have.all.keys(['foo', '_owner', '_progress', '_state', '_state_changed']);
+          expect(data).to.have.all.keys(['foo', '_owner', '_progress', '_state', '_state_changed', '_id']);
           done();
         } catch (error) {
           done(error);


### PR DESCRIPTION
This short PR aims at providing the worker with the task ID. It could be used to set new data with the same id but at a different location (sort of 'process & move' feature).