### PR TITLE
[Feature] Add/Remove workers dynamically.

### DIFF
--- a/test/lib/queue_worker.spec.js
+++ b/test/lib/queue_worker.spec.js
@@ -2117,7 +2117,7 @@ describe('QueueWorker', function() {
         setTimeout(function() {
           callbackComplete = true;
           resolve();
-        }, 250);
+        }, 100);
       });
     });
 
@@ -2147,7 +2147,7 @@ describe('QueueWorker', function() {
           } catch (errorB) {
             done(errorB);
           }
-        }, 100);
+        }, 300);
       });
     });
   });

--- a/test/lib/queue_worker.spec.js
+++ b/test/lib/queue_worker.spec.js
@@ -2117,7 +2117,7 @@ describe('QueueWorker', function() {
         setTimeout(function() {
           callbackComplete = true;
           resolve();
-        }, 100);
+        }, 250);
       });
     });
 

--- a/test/queue.spec.js
+++ b/test/queue.spec.js
@@ -159,6 +159,7 @@ describe('Queue', function() {
       var worker = q.addWorker()
       expect(q.getWorkerCount()).to.equal(2);
     });
+
     it('should add worker with correct process id', function() {
       var specId = 'test_task';
       var q = new th.Queue(th.testRef,{ specId: specId }, _.noop);
@@ -175,18 +176,21 @@ describe('Queue', function() {
       var workerShutdownPromise = q.shutdownWorker()
       expect(q.getWorkerCount()).to.equal(0);
     });
+
     it('should shutdown worker', function() {
       var q = new th.Queue(th.testRef, _.noop);
       expect(q.getWorkerCount()).to.equal(1);
       var workerShutdownPromise = q.shutdownWorker()
       return workerShutdownPromise
     });
-    it('should return undefined when no workers remaining', function() {
+
+    it('should reject when no workers remaining', function() {
       var q = new th.Queue(th.testRef, _.noop);
       expect(q.getWorkerCount()).to.equal(1);
       q.shutdownWorker()
-      var workerShutdownPromise = q.shutdownWorker()
-      expect(workerShutdownPromise).to.be.undefined
+      return q.shutdownWorker().catch(function(error) {
+        expect(error.message).to.equal('No workers to shutdown');
+      });
     });
   });
 

--- a/test/queue.spec.js
+++ b/test/queue.spec.js
@@ -144,6 +144,52 @@ describe('Queue', function() {
     });
   });
 
+  describe('#getWorkerCount', function() {
+    it('should return worker count with options.numWorkers', function() {
+      var numWorkers = 10
+      var q = new th.Queue(th.testRef, { numWorkers: numWorkers }, _.noop);
+      expect(q.getWorkerCount()).to.equal(numWorkers);
+    });
+  });
+
+  describe('#addWorker', function() {
+    it('should add worker', function() {
+      var q = new th.Queue(th.testRef, _.noop);
+      expect(q.getWorkerCount()).to.equal(1);
+      var worker = q.addWorker()
+      expect(q.getWorkerCount()).to.equal(2);
+    });
+    it('should add worker with correct process id', function() {
+      var specId = 'test_task';
+      var q = new th.Queue(th.testRef,{ specId: specId }, _.noop);
+      var worker = q.addWorker()
+      var specRegex = new RegExp('^' + specId + ':1:[a-f0-9\\-]{36}$');
+      expect(worker.processId).to.match(specRegex);
+    });
+  });
+
+  describe('#shutdownWorker', function() {
+    it('should remove worker', function() {
+      var q = new th.Queue(th.testRef, _.noop);
+      expect(q.getWorkerCount()).to.equal(1);
+      var workerShutdownPromise = q.shutdownWorker()
+      expect(q.getWorkerCount()).to.equal(0);
+    });
+    it('should shutdown worker', function() {
+      var q = new th.Queue(th.testRef, _.noop);
+      expect(q.getWorkerCount()).to.equal(1);
+      var workerShutdownPromise = q.shutdownWorker()
+      return workerShutdownPromise
+    });
+    it('should return undefined when no workers remaining', function() {
+      var q = new th.Queue(th.testRef, _.noop);
+      expect(q.getWorkerCount()).to.equal(1);
+      q.shutdownWorker()
+      var workerShutdownPromise = q.shutdownWorker()
+      expect(workerShutdownPromise).to.be.undefined
+    });
+  });
+
   describe('#shutdown', function() {
     var q;
 


### PR DESCRIPTION
### Description

I'm writing another project that monitors/scales firebase queues using wait-time and process-time and available system resources.

The way I currently have this working is to treat `Queues` as singleton workers and pass a factory method to my monitor/scaler which creates another `Queue` when it needs to add another worker. This is not logically optimal and adds unnecessary overhead (extra connections to firebase for the task and spec listeners). I could ofcourse simulataneous shutdown the current `Queue` and start another with my desired numWorkers param. This again seems unnecessary and a little dirty.

I think it would be better for me (and maybe others) if I could add/reduce the number of workers without having to A. create another `Queue`, B. Shutdown the current `Queue` start it again with new numWorkers parameter.

Huge N.B. caveat: I don't fully understand the `QueueWorker.prototype.setTaskSpec` and `QueueWorker.prototype._setUpTimeouts` methods. 

If @mbleigh or @drtriumph have time to look over this be much appreciated.

### Code sample

```
var q = new Queue(th.testRef, _.noop);
q.getWorkerCount()
q.addWorker()
q.removeWorker()
```

### Linter and test suite

Linting and tests passing

### Added tests

I added several tests. To cover the bulk of my changes.
The outstanding case is where a worker is added to a queue with a specified specID and before that spec has been retrieved from firebase. This is accounted for by not covered by tests.

I tried to write this with as few changes to the existing code. It would be good if things like creating the new queueWorker were refactored out and there weren't multiple for loops for setting the task specs of the workers.

### Sign our CLA
Signed
