### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
     "email": "firebase-support@google.com",
     "url": "https://firebase.google.com/"
   },
-  "homepage": "https://firebase.google.com/",
-  "repository": "https://github.com/firebase/firebase-queue.git",
   "homepage": "https://github.com/firebase/firebase-queue",
+  "repository": "https://github.com/firebase/firebase-queue.git",
   "main": "dist/queue.js",
   "files": [
     "dist/lib/**",
@@ -34,8 +33,8 @@
   "dependencies": {
     "firebase": "^3.0.0",
     "lodash": "^4.6.1",
-    "node-uuid": "^1.4.7",
     "rsvp": "^3.2.1",
+    "uuid": "^3.0.0",
     "winston": "^2.2.0"
   },
   "devDependencies": {

--- a/src/lib/queue_worker.js
+++ b/src/lib/queue_worker.js
@@ -2,7 +2,7 @@
 
 var firebase = require('firebase');
 var logger = require('winston');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var RSVP = require('rsvp');
 var _ = require('lodash');
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.