### PR TITLE
Updating the test suite to use firebase-admin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - '0.10'
 - '0.12'
 - '4'
-- '5'
+- '6'
 - stable
 sudo: false
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-- '0.10'
-- '0.12'
 - '4'
 - '6'
 - stable

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -18,7 +18,7 @@
 
 ## Purpose of a Queue
 
-Queues can be used in your Firebase app to organize workers or perform background work like generating thumbnails of images, filtering message contents and censoring data, or fanning data out to multiple locations in your Firebase database. First, let's define a few terms we'll use when talking about a queue:
+Queues can be used in your Firebase app to organize workers or perform background work like generating thumbnails of images, filtering message contents and censoring data, or fanning data out to multiple locations in your Firebase Database. First, let's define a few terms we'll use when talking about a queue:
   - `task` - a unit of work that a queue worker can process
   - `spec` - a definition of an operation that the queue will perform on matching tasks
   - `job` - one or more `spec`'s that specify a series of ordered operations to be performed
@@ -34,7 +34,7 @@ Using Firebase Queue, you can create specs for each of these tasks, and then use
 
 ## The Queue in Your Firebase Database
 
-The queue relies on having a Firebase database reference to coordinate workers e.g. `https://databaseName.firebaseio.com/queue`. This queue can be stored at any path in your Firebase database, and you can have multiple queues as well. The queue will respond to tasks pushed onto the `tasks` subtree and optionally read specifications from a `specs` subtree.
+The queue relies on having a Firebase Database reference to coordinate workers e.g. `https://databaseName.firebaseio.com/queue`. This queue can be stored at any path in your Firebase Database, and you can have multiple queues as well. The queue will respond to tasks pushed onto the `tasks` subtree and optionally read specifications from a `specs` subtree.
 
 ```
 queue
@@ -44,14 +44,14 @@ queue
 
 See [Custom references to tasks and specs](#custom-references-to-tasks-and-specs) for defining the locations of these other than the default.
 
-Firebase Queue works with a Firebase database reference from either the [firebase-admin](https://www.npmjs.com/package/firebase-admin) (for admin access) or [firebase](https://www.npmjs.com/package/firebase) (for end-user access) NPM module, though it is mainly intended to perform administrative actions. Check out [this blog post](https://firebase.googleblog.com/2016/11/bringing-firebase-to-your-server.html) for an introduction to firebase-admin.
+Firebase Queue works with a Firebase Database reference from either the [`firebase-admin`](https://www.npmjs.com/package/firebase-admin) (for admin access) or [`firebase`](https://www.npmjs.com/package/firebase) (for end-user access) npm package, though it is mainly intended to perform administrative actions. Check out [this blog post](https://firebase.googleblog.com/2016/11/bringing-firebase-to-your-server.html) for an introduction to `firebase-admin`.
 
 
 ## Queue Workers
 
 The basic unit of the queue is the queue worker: the function that claims a task, performs the appropriate processing on the data, and either returns the transformed data, or an appropriate error.
 
-You can start a worker process by passing in a Firebase database  [`ref`](https://firebase.google.com/docs/server/setup#initialize_the_sdk) along with a processing function ([described below](#the-processing-function)), as follows:
+You can start a worker process by passing in a Firebase Database  [`ref`](https://firebase.google.com/docs/server/setup#initialize_the_sdk) along with a processing function ([described below](#the-processing-function)), as follows:
 
 ```js
 // my_queue_worker.js
@@ -59,8 +59,9 @@ You can start a worker process by passing in a Firebase database  [`ref`](https:
 var Queue = require('firebase-queue');
 var admin = require('firebase-admin');
 
+var serviceAccount = require('path/to/serviceAccountCredentials.json')
 admin.initializeApp({
-  credential: admin.credential.cert('path/to/serviceAccountCredentials.json'),
+  credential: admin.credential.cert(serviceAccount),
   databaseURL: '<your-database-url>'
 });
 
@@ -415,7 +416,7 @@ tasksRef.push({
 });
 ```
 
-Your Firebase database should now look like this:
+Your Firebase Database should now look like this:
 
 ```
 root
@@ -436,8 +437,9 @@ When your users push `data` like the above into the `tasks` subtree, tasks will 
 var Queue = require('firebase-queue');
 var admin = require('firebase-admin');
 
+var serviceAccount = require('path/to/serviceAccountCredentials.json')
 admin.initializeApp({
-  credential: admin.credential.cert('path/to/serviceAccountCredentials.json'),
+  credential: admin.credential.cert(serviceAccount),
   databaseURL: '<your-database-url>'
 });
 
@@ -495,7 +497,7 @@ root
         - name: "Chris"
 ```
 
-Now, you want to fan the data out to the `messages` subtree of your Firebase database, using the spec, `fanout_message`, so you can set up a second processing function to find tasks whose `_state` is `sanitize_message_finished`:
+Now, you want to fan the data out to the `messages` subtree of your Firebase Database, using the spec, `fanout_message`, so you can set up a second processing function to find tasks whose `_state` is `sanitize_message_finished`:
 
 ```js
 ...
@@ -529,8 +531,9 @@ It is possible to specify the locations the queue uses for tasks and the specs e
 var Queue = require('firebase-queue');
 var admin = require('firebase-admin');
 
+var serviceAccount = require('path/to/serviceAccountCredentials.json')
 admin.initializeApp({
-  credential: admin.credential.cert('path/to/serviceAccountCredentials.json'),
+  credential: admin.credential.cert(serviceAccount),
   databaseURL: '<your-database-url>'
 });
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -59,7 +59,7 @@ You can start a worker process by passing in a Firebase Database  [`ref`](https:
 var Queue = require('firebase-queue');
 var admin = require('firebase-admin');
 
-var serviceAccount = require('path/to/serviceAccountCredentials.json')
+var serviceAccount = require('path/to/serviceAccountCredentials.json');
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
   databaseURL: '<your-database-url>'
@@ -437,7 +437,7 @@ When your users push `data` like the above into the `tasks` subtree, tasks will 
 var Queue = require('firebase-queue');
 var admin = require('firebase-admin');
 
-var serviceAccount = require('path/to/serviceAccountCredentials.json')
+var serviceAccount = require('path/to/serviceAccountCredentials.json');
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
   databaseURL: '<your-database-url>'
@@ -531,7 +531,7 @@ It is possible to specify the locations the queue uses for tasks and the specs e
 var Queue = require('firebase-queue');
 var admin = require('firebase-admin');
 
-var serviceAccount = require('path/to/serviceAccountCredentials.json')
+var serviceAccount = require('path/to/serviceAccountCredentials.json');
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
   databaseURL: '<your-database-url>'

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -44,6 +44,8 @@ queue
 
 See [Custom references to tasks and specs](#custom-references-to-tasks-and-specs) for defining the locations of these other than the default.
 
+Firebase Queue works with a Firebase database reference from either the [firebase-admin](https://www.npmjs.com/package/firebase-admin) (for admin access) or [firebase](https://www.npmjs.com/package/firebase) (for end-user access) NPM module, though it is mainly intended to perform administrative actions. Check out [this blog post](https://firebase.googleblog.com/2016/11/bringing-firebase-to-your-server.html) for an introduction to firebase-admin.
+
 
 ## Queue Workers
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -55,14 +55,14 @@ You can start a worker process by passing in a Firebase database  [`ref`](https:
 // my_queue_worker.js
 
 var Queue = require('firebase-queue');
-var firebase = require('firebase');
+var admin = require('firebase-admin');
 
-firebase.initializeApp({
-  serviceAccount: 'path/to/serviceAccountCredentials.json',
+admin.initializeApp({
+  credential: admin.credential.cert('path/to/serviceAccountCredentials.json'),
   databaseURL: '<your-database-url>'
 });
 
-var ref = firebase.database().ref('queue');
+var ref = admin.database().ref('queue');
 var queue = new Queue(ref, function(data, progress, resolve, reject) {
   // Read and process task data
   console.log(data);
@@ -432,14 +432,14 @@ When your users push `data` like the above into the `tasks` subtree, tasks will 
 // chat_message_sanitization.js
 
 var Queue = require('firebase-queue');
-var firebase = require('firebase');
+var admin = require('firebase-admin');
 
-firebase.initializeApp({
-  serviceAccount: 'path/to/serviceAccountCredentials.json',
+admin.initializeApp({
+  credential: admin.credential.cert('path/to/serviceAccountCredentials.json'),
   databaseURL: '<your-database-url>'
 });
 
-var db = firebase.database();
+var db = admin.database();
 var queueRef = db.ref('queue');
 var messagesRef = db.ref('messages');
 
@@ -525,14 +525,14 @@ It is possible to specify the locations the queue uses for tasks and the specs e
 
 ```js
 var Queue = require('firebase-queue');
-var firebase = require('firebase');
+var admin = require('firebase-admin');
 
-firebase.initializeApp({
-  serviceAccount: 'path/to/serviceAccountCredentials.json',
+admin.initializeApp({
+  credential: admin.credential.cert('path/to/serviceAccountCredentials.json'),
   databaseURL: '<your-database-url>'
 });
 
-var db = firebase.database();
+var db = admin.database();
 
 var jobsRef = db.ref('jobs');
 var specsRef = db.ref('specs');

--- a/package.json
+++ b/package.json
@@ -27,11 +27,7 @@
     "README.md",
     "package.json"
   ],
-  "peerDependencies": {
-    "firebase": "^2.4.2 || ^3.0.0"
-  },
   "dependencies": {
-    "firebase": "^3.0.0",
     "lodash": "^4.6.1",
     "rsvp": "^3.2.1",
     "uuid": "^3.0.0",
@@ -39,13 +35,14 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "chai-as-promised": "^5.3.0",
+    "chai-as-promised": "^6.0.0",
     "coveralls": "^2.11.8",
+    "firebase-admin": "^4.0.3",
     "gulp": "^3.9.1",
-    "gulp-eslint": "^2.0.0",
+    "gulp-eslint": "^3.0.1",
     "gulp-exit": "^0.0.2",
-    "gulp-istanbul": "^0.10.3",
-    "gulp-mocha": "^2.2.0",
+    "gulp-istanbul": "^1.1.1",
+    "gulp-mocha": "^3.0.1",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0"
   },

--- a/src/lib/queue_worker.js
+++ b/src/lib/queue_worker.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var firebase = require('firebase');
 var logger = require('winston');
 var uuid = require('uuid');
 var RSVP = require('rsvp');
@@ -10,7 +9,7 @@ var MAX_TRANSACTION_ATTEMPTS = 10;
 var DEFAULT_ERROR_STATE = 'error';
 var DEFAULT_RETRIES = 0;
 
-var SERVER_TIMESTAMP = firebase.database.ServerValue.TIMESTAMP;
+var SERVER_TIMESTAMP = {'.sv': 'timestamp'};
 
 function _getKey(snapshot) {
   return _.isFunction(snapshot.key) ? snapshot.key() : snapshot.key;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,17 +3,19 @@
 var _ = require('lodash');
 var path = require('path');
 var util = require('util');
-var firebase = require('firebase');
+var admin = require('firebase-admin');
 
-firebase.initializeApp({
-  serviceAccount: path.resolve(__dirname, './key.json'),
+var serviceAccount = require('./key.json');
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
   databaseURL: process.env.FB_QUEUE_TEST_DB_URL
 });
 
 module.exports = function() {
   var self = this;
 
-  this.testRef = firebase.database().ref(_.random(1, 2 << 29));
+  this.testRef = admin.database().ref(_.random(1, 2 << 29));
   this.offset = 0;
   self.testRef.root.child('.info/serverTimeOffset').on('value', function(snapshot) {
     self.offset = snapshot.val();


### PR DESCRIPTION
Fixes #90 

NPM (at least v3.10.8) seems to install optional dependencies by default which is not what we want I don't think. I think it's clear from the documentation that you always have to install firebase-queue alongside either firebase-admin or firebase, so let's just remove it from anything other than the devDependencies.