### PR TITLE
Add "retries" field to suggested specs rules

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -281,6 +281,9 @@ These don't have to use a custom token, for instance you could use `auth != null
           "timeout": {
             ".validate": "newData.isNumber() && newData.val() > 0"
           },
+          "retries": {
+            ".validate": "newData.isNumber() && newData.val() >= 0"
+          },
           "$other": {
             ".validate": false
           }


### PR DESCRIPTION
The `retries` field of the specs was missing from the suggested rules.
Together with `"$other": {  ".validate": false }` this meant that the retries parameter could not be used in specs.
