### PR TITLE
Added version number to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-queue",
-  "version": "0.0.0",
+  "version": "1.6.1",
   "description": "A fault-tolerant, multi-worker, multi-stage job pipeline built on Firebase",
   "keywords": [
     "job",


### PR DESCRIPTION
### Description

Catapult (the internal tool we use to release Firebase JavaScript libraries) now works without the `0.0.0` version placeholder in the `package.json` file. So, we can finally add the actual version numbers back into this file.

### Code sample

N/A